### PR TITLE
resolve postcss-scss

### DIFF
--- a/stylelint-config/index.js
+++ b/stylelint-config/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  customSyntax: "postcss-scss",
+  customSyntax: require.resolve("postcss-scss"),
   plugins: ["./rules/use-defined-css-var-when-available/index.js"],
   rules: {
     "monday-ui-style/use-defined-css-var-when-available": true,


### PR DESCRIPTION
This way consumers won't need to add `postcss-scss` as dependency
https://monday.monday.com/boards/245345663/pulses/2557660304