### PR TITLE
Fix/yonatanari/disabled text color revert

### DIFF
--- a/src/Themes/_hacker-theme.scss
+++ b/src/Themes/_hacker-theme.scss
@@ -53,8 +53,8 @@
   // disabled
   --disabled-background-color: #595959;
   --disabled-background-on-secondary-color: #595959;
-  --disabled-text-color: #5d6072;
-  --disabled-text-on-secondary-color: #5d6072;
+  --disabled-text-color: #{$color-wolf_gray-muted};
+  --disabled-text-on-secondary-color: #{$color-wolf_gray-muted};
 
   --dark-background-color: #303241;
   --dark-background-on-secondary-color: #595959;

--- a/src/config/tokens/themes/basic/keys/_keys.scss
+++ b/src/config/tokens/themes/basic/keys/_keys.scss
@@ -34,7 +34,7 @@ $allgrey-background-color: $color-riverstone_gray;
 $inverted-color-background: $color-mud_black;
 
 // System Semantics (state, status)
-$disabled-text-color: $color-asphalt-muted;
+$disabled-text-color: $color-asphalt;
 $disabled-background-color: $color-ui_grey-muted;
 
 $positive-color: $color-success;

--- a/src/config/tokens/themes/basic/palette/_palette.scss
+++ b/src/config/tokens/themes/basic/palette/_palette.scss
@@ -31,7 +31,6 @@ $color-mud_black: #323338;
 $color-riverstone_gray: #f6f7fb;
 // - Muted
 $color-ui_grey-muted: #ecedf5;
-$color-asphalt-muted: #bdbec7;
 
 // Text
 $color-asphalt: #676879;

--- a/src/config/tokens/themes/black/keys/_black-theme-keys.scss
+++ b/src/config/tokens/themes/black/keys/_black-theme-keys.scss
@@ -32,7 +32,7 @@ $theme-black-allgrey-background-color: $color-night;
 $theme-black-inverted-color-background: $color-smog;
 
 // System Semantics (state, status)
-$theme-black-disabled-text-color: $color-mouse-muted;
+$theme-black-disabled-text-color: $color-mouse;
 $theme-black-disabled-background-color: $color-dust-muted;
 
 $theme-black-positive-color: $positive-color;

--- a/src/config/tokens/themes/black/palette/_black-theme-palette.scss
+++ b/src/config/tokens/themes/black/palette/_black-theme-palette.scss
@@ -8,7 +8,6 @@ $color-night: #2c2c2c;
 $color-vanta: #111111;
 // - Muted
 $color-dust-muted: #3a3a3a;
-$color-mouse-muted: #5d5d5d;
 
 // Text
 $color-smog: #eeeeee;

--- a/src/config/tokens/themes/dark/keys/_dark-theme-keys.scss
+++ b/src/config/tokens/themes/dark/keys/_dark-theme-keys.scss
@@ -33,7 +33,7 @@ $theme-dark-allgrey-background-color: $color-graphite;
 $theme-dark-inverted-color-background: $color-snow_white; // todo: fix, value from basic theme
 
 // System Semantics (state, status)
-$theme-dark-disabled-text-color: $color-spacegrey_muted;
+$theme-dark-disabled-text-color: $color-wolf_gray-muted;
 $theme-dark-disabled-background-color: $color-silver_muted;
 
 $theme-dark-positive-color: $positive-color;

--- a/src/config/tokens/themes/dark/palette/_dark-theme-palette.scss
+++ b/src/config/tokens/themes/dark/palette/_dark-theme-palette.scss
@@ -20,7 +20,7 @@ $color-fog: #797e93;
 $color-snow: #d5d8df;
 // - Muted
 $color-silver_muted: #3c3f59;
-$color-spacegrey_muted: #5d6072;
+$color-wolf_gray-muted: rgba($color-wolf_gray, 0.75);
 
 // Text
 $color-spacegrey: #9699a5;


### PR DESCRIPTION
https://monday.monday.com/boards/245345663/pulses/2861456942 

Correct Disabled color token in all themes
* Revert basic theme value to $color-asphalt
* Removed $color-asphalt-muted from palette
* Revert black theme value to $color-mouse 
* Remove $color-mouse-muted from palette
* Add $color-wolf_gray-muted to palette
* Revert dark theme value to $color-wolf_gray-muted
* Correct Disabled color token: hacker theme
* Revert value to $color-wolf_gray-muted