### PR TITLE
Update disabled text color logic.

### DIFF
--- a/src/Themes/_hacker-theme.scss
+++ b/src/Themes/_hacker-theme.scss
@@ -53,8 +53,8 @@
   // disabled
   --disabled-background-color: #595959;
   --disabled-background-on-secondary-color: #595959;
-  --disabled-text-color: #{$color-wolf_gray-muted};
-  --disabled-text-on-secondary-color: #{$color-wolf_gray-muted};
+  --disabled-text-color: rgba(#{extract-rgb(#d5d8df)},0.1);
+  --disabled-text-on-secondary-color: rgba(#{extract-rgb(#d5d8df)},0.1);
 
   --dark-background-color: #303241;
   --dark-background-on-secondary-color: #595959;

--- a/src/config/tokens/core/_core-common.scss
+++ b/src/config/tokens/core/_core-common.scss
@@ -3,4 +3,4 @@
 // - common tokens defines misc global tokens
 
 // Common Opacity aliases
-$disabled-component-opacity: $opacity-40;
+$disabled-component-opacity: $opacity-38;

--- a/src/config/tokens/core/_core-opacity.scss
+++ b/src/config/tokens/core/_core-opacity.scss
@@ -7,6 +7,7 @@ $opacity-0: 0;
 $opacity-10: 0.1;
 $opacity-20: 0.2;
 $opacity-30: 0.3;
+$opacity-38: 0.38;
 $opacity-40: 0.4;
 $opacity-50: 0.5;
 $opacity-60: 0.6;

--- a/src/config/tokens/themes/basic/keys/_keys.scss
+++ b/src/config/tokens/themes/basic/keys/_keys.scss
@@ -34,7 +34,7 @@ $allgrey-background-color: $color-riverstone_gray;
 $inverted-color-background: $color-mud_black;
 
 // System Semantics (state, status)
-$disabled-text-color: $color-asphalt;
+$disabled-text-color: rgba($primary-text-color, var(--disabled-component-opacity));
 $disabled-background-color: $color-ui_grey-muted;
 
 $positive-color: $color-success;

--- a/src/config/tokens/themes/black/keys/_black-theme-keys.scss
+++ b/src/config/tokens/themes/black/keys/_black-theme-keys.scss
@@ -32,7 +32,7 @@ $theme-black-allgrey-background-color: $color-night;
 $theme-black-inverted-color-background: $color-smog;
 
 // System Semantics (state, status)
-$theme-black-disabled-text-color: $color-mouse;
+$theme-black-disabled-text-color: rgba($theme-black-primary-text-color, var(--disabled-component-opacity));
 $theme-black-disabled-background-color: $color-dust-muted;
 
 $theme-black-positive-color: $positive-color;

--- a/src/config/tokens/themes/dark/keys/_dark-theme-keys.scss
+++ b/src/config/tokens/themes/dark/keys/_dark-theme-keys.scss
@@ -33,7 +33,7 @@ $theme-dark-allgrey-background-color: $color-graphite;
 $theme-dark-inverted-color-background: $color-snow_white; // todo: fix, value from basic theme
 
 // System Semantics (state, status)
-$theme-dark-disabled-text-color: $color-wolf_gray-muted;
+$theme-dark-disabled-text-color: rgba($theme-dark-primary-text-color, var(--disabled-component-opacity));
 $theme-dark-disabled-background-color: $color-silver_muted;
 
 $theme-dark-positive-color: $positive-color;


### PR DESCRIPTION
https://monday.monday.com/boards/2861766393/pulses/2969517122

* Update disabled-component key to 0.38 ,
* Add opacity 0.38 registration value.
* Disabled text color use RGBA for {theme}-primary-text-color key with disabled-component key.
  * Modify Basic theme
  * Modify Dark theme
  * Modify Black theme
  * Modify Hacker theme