### PR TITLE
Brand colors

### DIFF
--- a/src/config/maps/themes/basic/keys/_keys.scss
+++ b/src/config/maps/themes/basic/keys/_keys.scss
@@ -39,7 +39,11 @@ $theme-basic-keys: (
   warning-color: $warning-color,
   warning-color-hover: $warning-color-hover,
   warning-color-selected: $warning-color-selected,
-  warning-color-selected-hover: $warning-color-selected-hover
+  warning-color-selected-hover: $warning-color-selected-hover,
+  brand-color: $primary-color,
+  brand-hover-color: $primary-hover-color,
+  brand-selected-color: $primary-selected-color,
+  brand-selected-hover-color: $primary-selected-hover-color
 );
 
 // ## BASIC THEME SHADOW MAP: basic theme's shadow color map.

--- a/src/config/maps/themes/black/keys/_black-theme-keys.scss
+++ b/src/config/maps/themes/black/keys/_black-theme-keys.scss
@@ -38,7 +38,11 @@ $theme-black-keys: (
   warning-color: $theme-black-warning-color,
   warning-color-hover: $theme-black-warning-color-hover,
   warning-color-selected: $theme-black-warning-color-selected,
-  warning-color-selected-hover: $theme-black-warning-color-selected-hover
+  warning-color-selected-hover: $theme-black-warning-color-selected-hover,
+  brand-color: $theme-black-primary-color,
+  brand-hover-color: $theme-black-primary-hover-color,
+  brand-selected-color: $theme-black-primary-selected-color,
+  brand-selected-hover-color: $theme-black-primary-selected-hover-color
 );
 
 // DARK THEME SHADOW MAP: dark theme's shadow color map.

--- a/src/config/maps/themes/dark/keys/_dark-theme-keys.scss
+++ b/src/config/maps/themes/dark/keys/_dark-theme-keys.scss
@@ -40,7 +40,11 @@ $theme-dark-keys: (
   warning-color: $theme-dark-warning-color,
   warning-color-hover: $theme-dark-warning-color-hover,
   warning-color-selected: $theme-dark-warning-color-selected,
-  warning-color-selected-hover: $theme-dark-warning-color-selected-hover
+  warning-color-selected-hover: $theme-dark-warning-color-selected-hover,
+  brand-color: $theme-dark-primary-color,
+  brand-hover-color: $theme-dark-primary-hover-color,
+  brand-selected-color: $theme-dark-primary-selected-color,
+  brand-selected-hover-color: $theme-dark-primary-selected-hover-color
 );
 
 // DARK THEME SHADOW MAP: dark theme's shadow color map.

--- a/src/config/maps/themes/hacker/keys/_hacker-theme-keys.scss
+++ b/src/config/maps/themes/hacker/keys/_hacker-theme-keys.scss
@@ -38,7 +38,11 @@ $theme-hacker-keys: (
   warning-color: $theme-hacker-warning-color,
   warning-color-hover: $theme-hacker-warning-color-hover,
   warning-color-selected: $theme-hacker-warning-color-selected,
-  warning-color-selected-hover: $theme-hacker-warning-color-selected-hover
+  warning-color-selected-hover: $theme-hacker-warning-color-selected-hover,
+  brand-color: $theme-hacker-primary-color,
+  brand-hover-color: $theme-hacker-primary-hover-color,
+  brand-selected-color: $theme-hacker-primary-selected-color,
+  brand-selected-hover-color: $theme-hacker-primary-selected-hover-color
 );
 
 // DARK THEME SHADOW MAP: dark theme's shadow color map.


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/4455105737

brand-colors by default are equal to primary-colors, but will be overridden from the monolith `product_themes` later